### PR TITLE
Batch commit for ingestor DB writes

### DIFF
--- a/containers/scheduler_ingest/ingestor/db_ops.py
+++ b/containers/scheduler_ingest/ingestor/db_ops.py
@@ -18,6 +18,9 @@ class IngestResult:
     fail_reason: str | None = None
 
 
+BATCH_SIZE = 500
+
+
 class IngestDB:
     """
     Updates:
@@ -40,130 +43,115 @@ class IngestDB:
     def _tevt(self, shard_id: int) -> str:
         return f"url_event_counter_{shard_id:03d}"
 
-    def process_result(self, rec: dict) -> IngestResult:
+    def _process_one_result(self, sess, rec: dict) -> IngestResult:
         url = rec["url"]
         shard_id = int(rec["shard_id"])
         domain_id = int(rec["domain_id"])
         status = rec["status"]
         fetched_at = datetime.fromisoformat(rec["fetched_at"]) if rec.get("fetched_at") else datetime.now(timezone.utc)
         fail_reason = rec.get("fail_reason")
-        #content = rec.get("content")
-        outlinks = rec.get("outlinks", [])
         content_hash = rec.get("content_hash")
 
         tcur = self._tcur(shard_id)
 
-        with self.Session() as sess:
-            try:
-                is_ok = status == "ok"
-                if is_ok and content_hash is not None:
-                    # Fetch old content_hash (to detect content_update) and current counters
-                    old = sess.execute(
-                        text(f"SELECT content_hash FROM {tcur} WHERE url = :url"),
-                        {"url": url},
-                    ).first()
-                    old_hash = old.content_hash if old else None
-                    is_upd = content_hash != old_hash
-                else:
-                    is_upd = False
+        is_ok = status == "ok"
+        if is_ok and content_hash is not None:
+            old = sess.execute(
+                text(f"SELECT content_hash FROM {tcur} WHERE url = :url"),
+                {"url": url},
+            ).first()
+            old_hash = old.content_hash if old else None
+            is_upd = content_hash != old_hash
+        else:
+            is_upd = False
 
-                # xmax=0 indicates inserted row in this tx (PostgreSQL)
-                row = sess.execute(
-                    text(f"""
-                    INSERT INTO {tcur} (
-                      url, domain_id,
-                      last_fetch_ok, last_content_update,
-                      num_fetch_ok_90d, num_fetch_fail_90d, num_content_update_90d,
-                      num_consecutive_fail, last_fail_reason,
-                      content_hash, should_crawl
-                    )
-                    VALUES (
-                      :url, :domain_id,
-                      CASE WHEN :is_ok THEN :fetched_at ELSE NULL END,
-                      CASE WHEN :is_upd THEN :fetched_at ELSE NULL END,
-                      :inc_ok, :inc_fail, :inc_upd,
-                      CASE WHEN :is_ok THEN 0 ELSE 1 END,
-                      CASE WHEN :is_ok THEN NULL ELSE :fail_reason END,
-                      :content_hash,
-                      FALSE
-                    )
-                    ON CONFLICT (url) DO UPDATE SET
-                      last_fetch_ok = COALESCE(EXCLUDED.last_fetch_ok, {tcur}.last_fetch_ok),
-                      last_content_update = COALESCE(EXCLUDED.last_content_update, {tcur}.last_content_update),
-                      num_fetch_ok_90d = {tcur}.num_fetch_ok_90d + EXCLUDED.num_fetch_ok_90d,
-                      num_fetch_fail_90d = {tcur}.num_fetch_fail_90d + EXCLUDED.num_fetch_fail_90d,
-                      num_content_update_90d = {tcur}.num_content_update_90d + EXCLUDED.num_content_update_90d,
-                      num_consecutive_fail = CASE
-                        WHEN :is_ok THEN 0
-                        ELSE {tcur}.num_consecutive_fail + 1
-                      END,
-                      last_fail_reason = EXCLUDED.last_fail_reason,
-                      content_hash = CASE
-                        WHEN :is_upd THEN EXCLUDED.content_hash
-                        ELSE {tcur}.content_hash
-                      END,
-                      should_crawl = FALSE
-                    RETURNING
-                      *, (xmax = 0) AS inserted;
-                    """),
-                    {
-                        "url": url,
-                        "domain_id": domain_id,
-                        "fetched_at": fetched_at,
-                        "is_ok": is_ok,
-                        "is_upd": is_upd,
-                        "inc_ok": int(is_ok),
-                        "inc_fail": 1 - int(is_ok),
-                        "inc_upd": int(is_upd),
-                        "fail_reason": fail_reason,
-                        "content_hash": content_hash,
-                    },
-                ).first()
+        row = sess.execute(
+            text(f"""
+            INSERT INTO {tcur} (
+              url, domain_id,
+              last_fetch_ok, last_content_update,
+              num_fetch_ok_90d, num_fetch_fail_90d, num_content_update_90d,
+              num_consecutive_fail, last_fail_reason,
+              content_hash, should_crawl
+            )
+            VALUES (
+              :url, :domain_id,
+              CASE WHEN :is_ok THEN :fetched_at ELSE NULL END,
+              CASE WHEN :is_upd THEN :fetched_at ELSE NULL END,
+              :inc_ok, :inc_fail, :inc_upd,
+              CASE WHEN :is_ok THEN 0 ELSE 1 END,
+              CASE WHEN :is_ok THEN NULL ELSE :fail_reason END,
+              :content_hash,
+              FALSE
+            )
+            ON CONFLICT (url) DO UPDATE SET
+              last_fetch_ok = COALESCE(EXCLUDED.last_fetch_ok, {tcur}.last_fetch_ok),
+              last_content_update = COALESCE(EXCLUDED.last_content_update, {tcur}.last_content_update),
+              num_fetch_ok_90d = {tcur}.num_fetch_ok_90d + EXCLUDED.num_fetch_ok_90d,
+              num_fetch_fail_90d = {tcur}.num_fetch_fail_90d + EXCLUDED.num_fetch_fail_90d,
+              num_content_update_90d = {tcur}.num_content_update_90d + EXCLUDED.num_content_update_90d,
+              num_consecutive_fail = CASE
+                WHEN :is_ok THEN 0
+                ELSE {tcur}.num_consecutive_fail + 1
+              END,
+              last_fail_reason = EXCLUDED.last_fail_reason,
+              content_hash = CASE
+                WHEN :is_upd THEN EXCLUDED.content_hash
+                ELSE {tcur}.content_hash
+              END,
+              should_crawl = FALSE
+            RETURNING
+              *, (xmax = 0) AS inserted;
+            """),
+            {
+                "url": url,
+                "domain_id": domain_id,
+                "fetched_at": fetched_at,
+                "is_ok": is_ok,
+                "is_upd": is_upd,
+                "inc_ok": int(is_ok),
+                "inc_fail": 1 - int(is_ok),
+                "inc_upd": int(is_upd),
+                "fail_reason": fail_reason,
+                "content_hash": content_hash,
+            },
+        ).first()
 
-                row_dict = dict(row._mapping)
-                inserted = row_dict.pop('inserted')
+        row_dict = dict(row._mapping)
+        inserted = row_dict.pop('inserted')
 
-                sess.execute(insert(url_state_history_table(shard_id)).values(**row_dict))
+        sess.execute(insert(url_state_history_table(shard_id)).values(**row_dict))
 
-                tevt = self._tevt(shard_id)
-                sess.execute(
-                    text(f"""
-                    INSERT INTO {tevt} (
-                      url, event_date,
-                      num_fetch_ok, num_fetch_fail, num_content_update,
-                      accounted
-                    )
-                    VALUES (
-                      :url, CURRENT_DATE,
-                      :ok, :fail, :upd,
-                      TRUE
-                    )
-                    ON CONFLICT (url, event_date) DO UPDATE SET
-                      num_fetch_ok = {tevt}.num_fetch_ok + EXCLUDED.num_fetch_ok,
-                      num_fetch_fail = {tevt}.num_fetch_fail + EXCLUDED.num_fetch_fail,
-                      num_content_update = {tevt}.num_content_update + EXCLUDED.num_content_update
-                    """),
-                    {"url": url, "ok": int(is_ok), "fail": 1 - int(is_ok), "upd": int(is_upd)},
-                )
-
-                sess.commit()
-
-            except Exception as e:
-                sess.rollback()
-                raise e
+        tevt = self._tevt(shard_id)
+        sess.execute(
+            text(f"""
+            INSERT INTO {tevt} (
+              url, event_date,
+              num_fetch_ok, num_fetch_fail, num_content_update,
+              accounted
+            )
+            VALUES (
+              :url, CURRENT_DATE,
+              :ok, :fail, :upd,
+              TRUE
+            )
+            ON CONFLICT (url, event_date) DO UPDATE SET
+              num_fetch_ok = {tevt}.num_fetch_ok + EXCLUDED.num_fetch_ok,
+              num_fetch_fail = {tevt}.num_fetch_fail + EXCLUDED.num_fetch_fail,
+              num_content_update = {tevt}.num_content_update + EXCLUDED.num_content_update
+            """),
+            {"url": url, "ok": int(is_ok), "fail": 1 - int(is_ok), "upd": int(is_upd)},
+        )
 
         return IngestResult(
             new_link=bool(inserted),
             domain_id=domain_id,
             is_ok=is_ok,
             is_upd=is_upd,
-            fail_reason=fail_reason
+            fail_reason=fail_reason,
         )
 
-    def process_link(self, rec: dict) -> bool:
-        """
-        Return True if a new url is found
-        """
+    def _process_one_link(self, sess, rec: dict) -> bool:
         url = rec["url"]
         shard_id = int(rec["shard_id"])
         domain_id = int(rec["domain_id"])
@@ -172,41 +160,59 @@ class IngestDB:
         tcur = self._tcur(shard_id)
         th = self._this(shard_id)
 
+        inserted_url = sess.execute(
+            text(f"""
+            INSERT INTO {tcur} (url, domain_id, domain_score)
+            VALUES (:url, :domain_id, :domain_score)
+            ON CONFLICT (url) DO NOTHING
+            RETURNING url;
+            """),
+            {"url": url, "domain_id": domain_id, "domain_score": domain_score},
+        ).scalar_one_or_none()
+
+        if inserted_url is not None:
+            sess.execute(
+                text(f"""
+                INSERT INTO {th} (url, domain_id, domain_score)
+                VALUES (:url, :domain_id, :domain_score)
+                RETURNING 1;
+                """),
+                {"url": url, "domain_id": domain_id, "domain_score": domain_score},
+            )
+
+        return inserted_url is not None
+
+    def process_batch(self, recs: list[dict]) -> list[IngestResult | bool]:
+        """Process a batch of records in a single transaction.
+
+        Returns a list matching input order. Each element is either:
+          - IngestResult for crawl result records
+          - bool for new link records (True if newly inserted)
+          - None if the record raised an error
+        """
+        results: list[IngestResult | bool | None] = []
         with self.Session() as sess:
             try:
-                inserted_url = sess.execute(
-                    text(f"""
-                    INSERT INTO {tcur} (url, domain_id, domain_score)
-                    VALUES (:url, :domain_id, :domain_score)
-                    ON CONFLICT (url) DO NOTHING
-                    RETURNING url;
-                    """),
-                    {
-                        "url": url,
-                        "domain_id": domain_id,
-                        "domain_score": domain_score,
-                    },
-                ).scalar_one_or_none()
-
-                if inserted_url is not None:
-                    sess.execute(
-                        text(f"""
-                        INSERT INTO {th} (url, domain_id, domain_score)
-                        VALUES (:url, :domain_id, :domain_score)
-                        RETURNING 1;
-                        """),
-                        {
-                            "url": url,
-                            "domain_id": domain_id,
-                            "domain_score": domain_score,
-                        },
-                    )
-
+                for i, rec in enumerate(recs):
+                    try:
+                        if rec.get("status") == "new":
+                            results.append(self._process_one_link(sess, rec))
+                        else:
+                            results.append(self._process_one_result(sess, rec))
+                    except Exception:
+                        sess.rollback()
+                        raise
                 sess.commit()
-
-                return (inserted_url is not None)
-            except Exception as e:
+            except Exception:
                 sess.rollback()
-                raise e
+                raise
+        return results
+
+    # Keep single-record methods for backward compatibility.
+    def process_result(self, rec: dict) -> IngestResult:
+        return self.process_batch([rec])[0]
+
+    def process_link(self, rec: dict) -> bool:
+        return self.process_batch([rec])[0]
 
 

--- a/containers/scheduler_ingest/ingestor/service.py
+++ b/containers/scheduler_ingest/ingestor/service.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from libs.ipc.jsonio import read_json, read_jsonl
 from libs.stats.delta_writer import StatsDeltaWriter
 
-from .db_ops import IngestDB, IngestResult
+from .db_ops import IngestDB, IngestResult, BATCH_SIZE
 
 
 class IngestService:
@@ -14,63 +14,66 @@ class IngestService:
         self.db = db
         self.stats = stats
 
+    def _accumulate_result(self, result, counters, domains):
+        if isinstance(result, bool):
+            if result:
+                counters["new_links"] += 1
+            return
+
+        if not result:
+            return
+
+        domains.setdefault(result.domain_id, defaultdict(int))
+
+        if result.new_link:
+            counters["new_links"] += 1
+        if result.is_ok:
+            counters["num_fetch_ok"] += 1
+            domains[result.domain_id]["num_fetch_ok"] += 1
+        else:
+            counters["num_fetch_fail"] += 1
+            domains[result.domain_id]["num_fetch_fail"] += 1
+        if result.is_upd:
+            counters["num_content_update"] += 1
+            domains[result.domain_id]["num_content_update"] += 1
+        if result.fail_reason:
+            counters.setdefault("fail_reasons", defaultdict(int))[result.fail_reason] += 1
+            domains[result.domain_id].setdefault("fail_reasons", defaultdict(int))[result.fail_reason] += 1
+
     def process_folder(self, folder: Path):
         print(f"[ingestor {self.ingestor_id:02d}] start processing '{folder}'", flush=True)
         file_cnt = 0
         counters = defaultdict(int)
         domains = {}
 
+        # Collect all records first, then process in batches.
+        all_recs = []
         for f in folder.iterdir():
             if not f.is_file():
                 continue
-
             if f.suffix == ".json":
-                recs = [read_json(f)]
+                all_recs.append(read_json(f))
                 file_cnt += 1
             elif f.suffix == ".jsonl":
-                recs = read_jsonl(f)
+                all_recs.extend(read_jsonl(f))
                 file_cnt += 1
-            else:
-                continue
-            
-            for rec in recs:
-                try:
-                    if rec.get("status") == "new":
-                        if self.db.process_link(rec):
-                            # discover new link
-                            counters["new_links"] += 1
-                        continue
 
-                    result = self.db.process_result(rec)
-                    if not result:
-                        continue
-
-                    domains.setdefault(result.domain_id, defaultdict(int))
-
-                    if result.new_link:
-                        counters["new_links"] += 1
-                    if result.is_ok:
-                        counters["num_fetch_ok"] += 1
-                        domains[result.domain_id]["num_fetch_ok"] += 1
-                    else:
-                        counters["num_fetch_fail"] += 1
-                        domains[result.domain_id]["num_fetch_fail"] += 1
-                    if result.is_upd:
-                        counters["num_content_update"] += 1
-                        domains[result.domain_id]["num_content_update"] += 1
-                    if result.fail_reason:
-                        counters.setdefault("fail_reasons", defaultdict(int))[result.fail_reason] += 1
-                        domains[result.domain_id].setdefault("fail_reasons", defaultdict(int))[result.fail_reason] += 1
-                except Exception as e:
-                    print(f"[ingestor {self.ingestor_id:02d}] ERROR: {e}", flush=True)
-                    counters["error_count"] += 1
-                    counters["ingest_error"] += 1
+        for i in range(0, len(all_recs), BATCH_SIZE):
+            batch = all_recs[i : i + BATCH_SIZE]
+            try:
+                results = self.db.process_batch(batch)
+                for result in results:
+                    self._accumulate_result(result, counters, domains)
+            except Exception as e:
+                print(f"[ingestor {self.ingestor_id:02d}] ERROR in batch: {e}", flush=True)
+                counters["error_count"] += len(batch)
+                counters["ingest_error"] += len(batch)
 
         domains.pop(None, None)
         self.stats.write(
             source="ingestor",
             counters=counters,
-            domains=domains
+            domains=domains,
         )
         print(f"[ingestor {self.ingestor_id:02d}] finish processing '{folder}', {file_cnt} files", flush=True)
 


### PR DESCRIPTION
## Summary

- Ingestor now commits in batches of 500 records instead of per-record
- Eliminates N sessions and N commits per folder, reducing round-trip overhead to DB

## Changes

- `db_ops.py`: Extract per-record logic into `_process_one_result` / `_process_one_link`, add `process_batch()` that runs all records in a single session/transaction
- `service.py`: Collect all records from a folder first, then process in `BATCH_SIZE` chunks

## Before

```
for rec in recs:
    with Session() as sess:
        # 4 queries
        sess.commit()  # commit per record
```

## After

```
with Session() as sess:
    for rec in batch:  # up to 500
        # 4 queries (same logic, shared session)
    sess.commit()  # single commit per batch
```

## Context

Addresses the IPC bottleneck identified in #6: ingestor_03 (shard 056, 121M rows) falls behind because per-record commits dominate wall time.