### PR TITLE
Fix golden_inject domain extraction and migrate legacy subdomain rows

### DIFF
--- a/docs/06-maintenance-scripts.md
+++ b/docs/06-maintenance-scripts.md
@@ -26,7 +26,20 @@ uv run scripts/migrate_add_source.py [--dry-run]
 uv run scripts/golden_inject.py [--dry-run]
 ```
 
-## 6.3 `constants.py`
+## 6.3 `migrate_merge_subdomain_rows.py`
+
+- One-time migration.
+- Cleans up legacy `domain_state` rows in subdomain form (e.g. `en.wikipedia.org`) left by an older `golden_inject` that used `urlparse().hostname` instead of eTLD+1.
+- For each dirty row, merges per-shard `url_state_current`, `url_event_counter`, `content_feature_current`, and `domain_stats_daily` into the canonical `(shard, domain_id)`. URL conflicts keep the canonical row and bump `source` to `GREATEST`. History tables are left untouched (append-only).
+- Skips rows whose `domain` value is not a valid DNS hostname (anchor-text leakage).
+- Default is `--dry-run`; pass `--execute` to mutate. `--domain-like` limits scope.
+
+```bash
+uv run scripts/migrate_merge_subdomain_rows.py --dry-run
+uv run scripts/migrate_merge_subdomain_rows.py --execute
+```
+
+## 6.4 `constants.py`
 
 Shared constants:
 

--- a/scripts/golden_inject.py
+++ b/scripts/golden_inject.py
@@ -12,9 +12,9 @@ import argparse
 import hashlib
 import logging
 from pathlib import Path
-from urllib.parse import urlparse
 
 import psycopg2
+import tldextract
 
 from constants import NUM_SHARDS, CRAWLERDB, METRICDB, SOURCE_GOLDEN
 from libs.config.loader import load_yaml
@@ -45,11 +45,12 @@ def domain_to_shard(domain: str, overrides: dict[str, int]) -> int:
 
 
 def extract_domain(url: str) -> str | None:
-    try:
-        parsed = urlparse(url)
-        return parsed.hostname
-    except Exception:
+    # Must match crawler spider's _extract_domain (eTLD+1) so golden and
+    # natural-discovery rows share the same domain_id / shard.
+    e = tldextract.extract(url)
+    if not e.suffix or not e.domain:
         return None
+    return f"{e.domain}.{e.suffix}"
 
 
 def fetch_injectable_batch_ids(metric_cur) -> list[int]:

--- a/scripts/migrate_merge_subdomain_rows.py
+++ b/scripts/migrate_merge_subdomain_rows.py
@@ -1,0 +1,302 @@
+"""
+Migration: merge subdomain-form domain_state rows into their eTLD+1
+canonical domain, fixing legacy rows left by golden_inject's old
+urlparse().hostname path (e.g. `en.wikipedia.org` -> `wikipedia.org`).
+
+For each dirty row, moves per-shard url_state_current, url_event_counter,
+content_feature_current, and domain_stats_daily to the canonical
+(shard, domain_id); on URL conflicts keeps the canonical row and bumps
+`source` to GREATEST. History tables are left untouched (append-only).
+
+Usage:
+    uv run scripts/migrate_merge_subdomain_rows.py --dry-run
+    uv run scripts/migrate_merge_subdomain_rows.py --execute
+"""
+
+import argparse
+import hashlib
+import logging
+import re
+from pathlib import Path
+
+import psycopg2
+import tldextract
+
+from constants import NUM_SHARDS, CRAWLERDB
+from libs.config.loader import load_yaml
+
+# Skip rows whose `domain` value is anchor-text leakage (contains spaces,
+# punctuation). Matches strict DNS label form.
+DNS_HOST_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?)*$")
+
+INGEST_CONFIG = (
+    Path(__file__).resolve().parents[1]
+    / "containers/scheduler_ingest/config/ingest.yaml"
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger(__name__)
+
+
+def load_domain_overrides() -> dict[str, int]:
+    try:
+        cfg = load_yaml(str(INGEST_CONFIG))
+    except FileNotFoundError:
+        return {}
+    return dict((cfg.get("router") or {}).get("domain_overrides") or {})
+
+
+def domain_to_shard(domain: str, overrides: dict[str, int]) -> int:
+    if domain in overrides:
+        return int(overrides[domain])
+    h = hashlib.md5((domain or "unknown").encode("utf-8")).hexdigest()
+    return int(h, 16) % NUM_SHARDS
+
+
+def canonical_domain(domain: str) -> str | None:
+    try:
+        e = tldextract.extract(domain)
+    except Exception:
+        return None
+    if not e.suffix or not e.domain:
+        return None
+    return f"{e.domain}.{e.suffix}"
+
+
+def ensure_canonical(cur, domain: str, shard_id: int) -> int:
+    cur.execute(
+        """
+        INSERT INTO domain_state (domain, shard_id)
+        VALUES (%s, %s)
+        ON CONFLICT (domain) DO NOTHING
+        """,
+        (domain, shard_id),
+    )
+    cur.execute("SELECT domain_id FROM domain_state WHERE domain = %s", (domain,))
+    return int(cur.fetchone()[0])
+
+
+def merge_one(cur, bad, good, dry_run: bool) -> dict:
+    """Migrate all per-shard rows from bad -> good. Returns counts."""
+    bad_domain, bad_shard, bad_did = bad
+    good_domain, good_shard, good_did = good
+
+    cur.execute(
+        f"SELECT COUNT(*) FROM url_state_current_{bad_shard:03d} WHERE domain_id=%s",
+        (bad_did,),
+    )
+    n_cur = cur.fetchone()[0]
+    cur.execute(
+        f"SELECT COUNT(*) FROM content_feature_current_{bad_shard:03d} WHERE domain_id=%s",
+        (bad_did,),
+    )
+    n_feat = cur.fetchone()[0]
+    cur.execute(
+        """
+        SELECT COUNT(*) FROM domain_stats_daily WHERE domain_id = %s
+        """,
+        (bad_did,),
+    )
+    n_stats = cur.fetchone()[0]
+
+    log.info(
+        "  %s (shard=%d did=%d) -> %s (shard=%d did=%d): url=%d feat=%d stats=%d",
+        bad_domain, bad_shard, bad_did,
+        good_domain, good_shard, good_did,
+        n_cur, n_feat, n_stats,
+    )
+
+    if dry_run:
+        return {"url_current": n_cur, "feat_current": n_feat, "stats_daily": n_stats}
+
+    cur.execute(
+        f"""
+        INSERT INTO url_state_current_{good_shard:03d} AS g
+          (url, domain_id, first_seen, last_scheduled, last_fetch_ok,
+           last_content_update, num_scheduled_90d, num_fetch_ok_90d,
+           num_fetch_fail_90d, num_content_update_90d, num_consecutive_fail,
+           last_fail_reason, content_hash, should_crawl, url_score,
+           domain_score, source)
+        SELECT url, %s, first_seen, last_scheduled, last_fetch_ok,
+               last_content_update, num_scheduled_90d, num_fetch_ok_90d,
+               num_fetch_fail_90d, num_content_update_90d, num_consecutive_fail,
+               last_fail_reason, content_hash, should_crawl, url_score,
+               domain_score, source
+        FROM url_state_current_{bad_shard:03d}
+        WHERE domain_id = %s
+        ON CONFLICT (url) DO UPDATE
+          SET source = GREATEST(g.source, EXCLUDED.source)
+        """,
+        (good_did, bad_did),
+    )
+    cur.execute(
+        f"DELETE FROM url_state_current_{bad_shard:03d} WHERE domain_id=%s",
+        (bad_did,),
+    )
+
+    # url_event_counter has no domain_id column; match via the URLs we
+    # just inserted into good_shard.
+    cur.execute(
+        f"""
+        INSERT INTO url_event_counter_{good_shard:03d} AS g
+          (url, event_date, num_scheduled, num_fetch_ok, num_fetch_fail,
+           num_content_update, accounted)
+        SELECT b.url, b.event_date, b.num_scheduled, b.num_fetch_ok,
+               b.num_fetch_fail, b.num_content_update, b.accounted
+        FROM url_event_counter_{bad_shard:03d} b
+        JOIN url_state_current_{good_shard:03d} c ON c.url = b.url
+        WHERE c.domain_id = %s
+        ON CONFLICT (url, event_date) DO UPDATE
+          SET num_scheduled      = g.num_scheduled      + EXCLUDED.num_scheduled,
+              num_fetch_ok       = g.num_fetch_ok       + EXCLUDED.num_fetch_ok,
+              num_fetch_fail     = g.num_fetch_fail     + EXCLUDED.num_fetch_fail,
+              num_content_update = g.num_content_update + EXCLUDED.num_content_update,
+              -- OR, not AND: accounted=TRUE means "still needs rolloff".
+              -- AND would silently mark pending events as done and leave
+              -- 90d counters inflated.
+              accounted          = g.accounted OR EXCLUDED.accounted
+        """,
+        (good_did,),
+    )
+    cur.execute(
+        f"""
+        DELETE FROM url_event_counter_{bad_shard:03d} b
+        USING url_state_current_{good_shard:03d} c
+        WHERE b.url = c.url AND c.domain_id = %s
+        """,
+        (good_did,),
+    )
+
+    cur.execute(
+        f"""
+        INSERT INTO content_feature_current_{good_shard:03d} AS g
+          (url, domain_id, fetched_at, content_length, content_hash, num_links)
+        SELECT url, %s, fetched_at, content_length, content_hash, num_links
+        FROM content_feature_current_{bad_shard:03d}
+        WHERE domain_id = %s
+        ON CONFLICT (url) DO UPDATE
+          SET domain_id      = EXCLUDED.domain_id,
+              fetched_at     = EXCLUDED.fetched_at,
+              content_length = EXCLUDED.content_length,
+              content_hash   = EXCLUDED.content_hash,
+              num_links      = EXCLUDED.num_links
+          WHERE EXCLUDED.fetched_at > g.fetched_at
+        """,
+        (good_did, bad_did),
+    )
+    cur.execute(
+        f"DELETE FROM content_feature_current_{bad_shard:03d} WHERE domain_id=%s",
+        (bad_did,),
+    )
+
+    cur.execute(
+        """
+        INSERT INTO domain_stats_daily AS g
+          (domain_id, event_date, shard_id, num_scheduled, num_fetch_ok,
+           num_fetch_fail, num_content_update, fail_reasons)
+        SELECT %s, event_date, %s, num_scheduled, num_fetch_ok,
+               num_fetch_fail, num_content_update, fail_reasons
+        FROM domain_stats_daily
+        WHERE domain_id = %s
+        ON CONFLICT (domain_id, event_date) DO UPDATE
+          SET num_scheduled      = g.num_scheduled      + EXCLUDED.num_scheduled,
+              num_fetch_ok       = g.num_fetch_ok       + EXCLUDED.num_fetch_ok,
+              num_fetch_fail     = g.num_fetch_fail     + EXCLUDED.num_fetch_fail,
+              num_content_update = g.num_content_update + EXCLUDED.num_content_update,
+              fail_reasons       = g.fail_reasons || EXCLUDED.fail_reasons
+        """,
+        (good_did, good_shard, bad_did),
+    )
+    cur.execute("DELETE FROM domain_stats_daily WHERE domain_id=%s", (bad_did,))
+
+    cur.execute("DELETE FROM domain_state WHERE domain_id=%s", (bad_did,))
+
+    return {"url_current": n_cur, "feat_current": n_feat, "stats_daily": n_stats}
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dry-run", action="store_true", default=True)
+    p.add_argument("--execute", dest="dry_run", action="store_false",
+                   help="Actually perform the migration")
+    p.add_argument("--domain-like", default=None,
+                   help="Optional SQL LIKE filter on domain_state.domain, "
+                        "e.g. '%%.wikipedia.org' to limit scope")
+    args = p.parse_args()
+
+    overrides = load_domain_overrides()
+    conn = psycopg2.connect(**CRAWLERDB)
+    conn.autocommit = False
+    cur = conn.cursor()
+
+    try:
+        if args.domain_like:
+            cur.execute(
+                "SELECT domain, shard_id, domain_id FROM domain_state WHERE domain LIKE %s ORDER BY domain",
+                (args.domain_like,),
+            )
+        else:
+            cur.execute(
+                "SELECT domain, shard_id, domain_id FROM domain_state ORDER BY domain"
+            )
+        rows = cur.fetchall()
+
+        dirty = []
+        unparseable = 0
+        skipped_junk = 0
+        for domain, shard_id, did in rows:
+            if not DNS_HOST_RE.match(domain or ""):
+                skipped_junk += 1
+                continue
+            canon = canonical_domain(domain)
+            if canon is None:
+                unparseable += 1
+                continue
+            if canon == domain:
+                continue
+            dirty.append((domain, shard_id, did, canon))
+
+        log.info("scanned=%d dirty=%d unparseable=%d junk=%d",
+                 len(rows), len(dirty), unparseable, skipped_junk)
+        if not dirty:
+            return
+
+        totals = {"url_current": 0, "feat_current": 0, "stats_daily": 0, "domains": 0}
+        for bad_domain, bad_shard, bad_did, canon in dirty:
+            canon_shard = domain_to_shard(canon, overrides)
+            if args.dry_run:
+                cur.execute("SELECT domain_id FROM domain_state WHERE domain=%s", (canon,))
+                r = cur.fetchone()
+                canon_did = int(r[0]) if r else -1
+            else:
+                canon_did = ensure_canonical(cur, canon, canon_shard)
+
+            stats = merge_one(
+                cur,
+                bad=(bad_domain, bad_shard, bad_did),
+                good=(canon, canon_shard, canon_did),
+                dry_run=args.dry_run,
+            )
+            for k in ("url_current", "feat_current", "stats_daily"):
+                totals[k] += stats[k]
+            totals["domains"] += 1
+
+            if not args.dry_run:
+                conn.commit()
+
+        tag = "[DRY-RUN] " if args.dry_run else ""
+        log.info(
+            "%sdomains=%d url_current=%d feat_current=%d stats_daily=%d",
+            tag, totals["domains"], totals["url_current"],
+            totals["feat_current"], totals["stats_daily"],
+        )
+
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Switch `golden_inject.extract_domain` from `urlparse().hostname` to `tldextract` (eTLD+1), matching crawler spider so golden and natural-discovery rows share the same `domain_id` / shard
- Add `scripts/migrate_merge_subdomain_rows.py` to clean up the 3,026 legacy `domain_state` rows left in subdomain form by the old behavior

## Migration

Per dirty domain, merges `url_state_current`, `url_event_counter`, `content_feature_current`, `domain_stats_daily` into the canonical `(shard, domain_id)` then drops the bad `domain_state` row. Conflict resolution:

- `source`: `GREATEST` (never downgrade golden)
- `accounted`: `OR` (never silently drop pending rolloff)
- `content_feature`: newer `fetched_at` wins
- `stats_daily`: SUM counters, JSONB `||` for `fail_reasons`

History tables untouched (append-only). Per-domain commit, `--dry-run` default.

## Dry-run

```
scanned=5,500,874 dirty=3,026 junk=35,535
[DRY-RUN] domains=3,026 url_current=11,820 stats_daily=18
```

## Usage

```bash
uv run scripts/migrate_merge_subdomain_rows.py --dry-run
uv run scripts/migrate_merge_subdomain_rows.py --execute
```