### PR TITLE
Phase 1: record first parent URL on link discovery

### DIFF
--- a/containers/scheduler_ingest/ingestor/db_ops.py
+++ b/containers/scheduler_ingest/ingestor/db_ops.py
@@ -53,6 +53,7 @@ _HIST_COLS = (
     "url_score",
     "domain_score",
     "source",
+    "discovered_from",
 )
 
 
@@ -263,13 +264,13 @@ class IngestDB:
                 unique_items.append((idx, rec))
 
         link_rows = [
-            (rec["url"], int(rec["domain_id"]), float(rec.get("domain_score", 0.0)))
+            (rec["url"], int(rec["domain_id"]), float(rec.get("domain_score", 0.0)), rec.get("discovered_from"))
             for _, rec in unique_items
         ]
         inserted_rows = execute_values(
             cur,
             f"""
-            INSERT INTO {tcur} (url, domain_id, domain_score)
+            INSERT INTO {tcur} (url, domain_id, domain_score, discovered_from)
             VALUES %s
             ON CONFLICT (url) DO NOTHING
             RETURNING url
@@ -284,7 +285,7 @@ class IngestDB:
         if history_rows:
             execute_values(
                 cur,
-                f"INSERT INTO {this} (url, domain_id, domain_score) VALUES %s",
+                f"INSERT INTO {this} (url, domain_id, domain_score, discovered_from) VALUES %s",
                 history_rows,
                 page_size=len(history_rows),
             )

--- a/containers/scheduler_ingest/router/service.py
+++ b/containers/scheduler_ingest/router/service.py
@@ -118,9 +118,10 @@ class RouterService:
                                 # resolve domain_id from DB (insert if missing)
                                 domain_id, _ = domain_resolver.ensure_and_get(domain, shard_id)
 
+                                src_url = rec.get("url")
                                 new_outlinks = []
                                 for link in outlinks:
-                                    l = self._process_link(domain_resolver, link)
+                                    l = self._process_link(domain_resolver, link, src_url)
                                     if l:
                                         new_outlinks.append(l)
 
@@ -170,7 +171,7 @@ class RouterService:
             )
         print(f"[router {self.cfg.router_id:02d}] finish processing '{folder}', {file_cnt} files", flush=True)
 
-    def _process_link(self, domain_resolver: DomainResolver, link: Dict[str, str]) -> Optional[Dict[str, Any]]:
+    def _process_link(self, domain_resolver: DomainResolver, link: Dict[str, str], src_url: Optional[str]) -> Optional[Dict[str, Any]]:
         url = link.get("url")
         domain = link.get("domain")
         anchor = link.get("anchor")
@@ -188,6 +189,7 @@ class RouterService:
                 "shard_id": shard_id,
                 "domain_id": domain_id,
                 "domain_score": domain_score,
+                "discovered_from": src_url,
             }
 
             out_dir = self._out_dir(ingestor_id)

--- a/docs/04-sql-schema-design.md
+++ b/docs/04-sql-schema-design.md
@@ -124,6 +124,7 @@ Key columns:
 - quality/failure: `num_consecutive_fail`, `last_fail_reason`, `content_hash`
 - scheduling flags/signals: `should_crawl`, `url_score`, `domain_score`
 - provenance: `source SMALLINT NOT NULL DEFAULT 0` (`0` = natural discovery, `1` = golden set membership; see `scripts/golden_inject.py`)
+- provenance: `discovered_from VARCHAR` (parent page URL on first discovery; NULL for golden-injected and seed URLs; first parent wins via `ON CONFLICT DO NOTHING`)
 
 Write patterns:
 

--- a/docs/06-maintenance-scripts.md
+++ b/docs/06-maintenance-scripts.md
@@ -26,7 +26,19 @@ uv run scripts/migrate_add_source.py [--dry-run]
 uv run scripts/golden_inject.py [--dry-run]
 ```
 
-## 6.3 `constants.py`
+## 6.3 `migrate_add_discovered_from.py`
+
+- One-time migration.
+- Adds `discovered_from VARCHAR` (nullable, no default) to all 256 shards of `url_state_current_{shard}` and `url_state_history_{shard}` (512 ALTERs total).
+- Idempotent via `IF NOT EXISTS`.
+- PG 11+ treats this as metadata-only, no table rewrite.
+- Phase 1 of NTU-CSIE5376/WebCrawler#6: ingestor `_bulk_links` writes the parent page URL on first discovery; `ON CONFLICT DO NOTHING` preserves the first writer.
+
+```bash
+uv run scripts/migrate_add_discovered_from.py [--dry-run]
+```
+
+## 6.4 `constants.py`
 
 Shared constants:
 

--- a/scripts/migrate_add_discovered_from.py
+++ b/scripts/migrate_add_discovered_from.py
@@ -1,0 +1,68 @@
+"""
+Migration: add `discovered_from` column to all url_state_current_{shard}
+and url_state_history_{shard} tables.
+
+  discovered_from VARCHAR
+    NULL for golden-injected and seed URLs;
+    set to the parent page URL on first discovery via outlink.
+    First-parent-only: ON CONFLICT DO NOTHING preserves the first writer.
+
+PG 11+ handles ADD COLUMN without a DEFAULT as metadata-only,
+so this does not rewrite any table data.
+
+Usage:
+    uv run scripts/migrate_add_discovered_from.py [--dry-run]
+"""
+
+import argparse
+import logging
+
+import psycopg2
+
+from constants import NUM_SHARDS, CRAWLERDB
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Add discovered_from column to url_state shard tables"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print SQL without executing"
+    )
+    args = parser.parse_args()
+
+    conn = psycopg2.connect(**CRAWLERDB)
+    cur = conn.cursor()
+
+    prefixes = ("url_state_current", "url_state_history")
+
+    try:
+        for prefix in prefixes:
+            for i in range(NUM_SHARDS):
+                table = f"{prefix}_{i:03d}"
+                sql = f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS discovered_from VARCHAR"
+
+                if args.dry_run:
+                    log.info("[DRY-RUN] %s", sql)
+                else:
+                    cur.execute(sql)
+
+        total = NUM_SHARDS * len(prefixes)
+        if not args.dry_run:
+            conn.commit()
+            log.info("Done: ran ALTER TABLE on %d tables", total)
+        else:
+            log.info("[DRY-RUN] Would alter %d tables", total)
+
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Phase 1 of NTU-CSIE5376/WebCrawler#6: record the first parent page URL when a new outlink is ingested
- Add `scripts/migrate_add_discovered_from.py` to add the column to all 256 `url_state_current_{shard}` and `url_state_history_{shard}` tables

## Schema

```sql
ALTER TABLE url_state_current_{000..255}
  ADD COLUMN IF NOT EXISTS discovered_from VARCHAR;
ALTER TABLE url_state_history_{000..255}
  ADD COLUMN IF NOT EXISTS discovered_from VARCHAR;
```

Nullable, no default. PG 11+ handles this as metadata-only (no table rewrite).

## Semantics

- Existing rows: `NULL` (no parent recorded retroactively)
- Newly discovered URLs: parent page URL on first ingest
- Re-discovered URLs: `ON CONFLICT DO NOTHING` preserves the original parent
- Golden-injected and seed URLs: `NULL` (no parent by definition)

## Pipeline changes

- Spider already emits `outlinks` with the parent URL implicit at the record top level. No spider change.
- `router._process_link`: forward the parent URL into the new-status jsonl as `discovered_from`.
- `ingestor._bulk_links`: include `discovered_from` in the current and history INSERTs. `_HIST_COLS` updated so the result path's history snapshot also carries the column via `RETURNING`.

## Phase 2 note

A `url_link` model already exists in `libs/db/models/link/url_link.py` for the all-parents case. Not wired in this PR: as a single non-sharded table at current QPS this would balloon storage quickly. Recommended to revisit as sharded `url_link_{shard}` and/or sampled if Phase 2 is needed.

## Usage

```bash
uv run scripts/migrate_add_discovered_from.py --dry-run
uv run scripts/migrate_add_discovered_from.py
```