### PR TITLE
Capture YouTube video metadata from fetched video pages

### DIFF
--- a/containers/scheduler_ingest/feature_extractor/db_ops.py
+++ b/containers/scheduler_ingest/feature_extractor/db_ops.py
@@ -17,9 +17,43 @@ class FeatureDB:
     Updates:
       - content_feature_current_{shard}
       - content_feature_history_{shard}
+      - youtube_video_meta (current-only, unsharded)
     """
     def __init__(self, Session: sessionmaker):
         self.Session = Session
+
+    def process_youtube(self, rec: dict) -> None:
+        if len(rec["url"]) > MAX_URL_LEN:
+            return
+        with self.Session() as sess:
+            try:
+                sess.execute(
+                    text("""
+                    INSERT INTO youtube_video_meta (
+                      video_id, url, channel_id, channel_title, video_title,
+                      view_count, length_seconds, keywords, fetched_at
+                    )
+                    VALUES (
+                      :video_id, :url, :channel_id, :channel_title, :video_title,
+                      :view_count, :length_seconds, :keywords, :fetched_at
+                    )
+                    ON CONFLICT (video_id) DO UPDATE SET
+                      url = EXCLUDED.url,
+                      channel_id = EXCLUDED.channel_id,
+                      channel_title = EXCLUDED.channel_title,
+                      video_title = EXCLUDED.video_title,
+                      view_count = EXCLUDED.view_count,
+                      length_seconds = EXCLUDED.length_seconds,
+                      keywords = EXCLUDED.keywords,
+                      fetched_at = EXCLUDED.fetched_at
+                      ;
+                    """),
+                    rec,
+                )
+                sess.commit()
+            except Exception as e:
+                sess.rollback()
+                raise e
 
     def _tcur(self, shard_id: int) -> str:
         return f"content_feature_current_{shard_id:03d}"

--- a/containers/scheduler_ingest/feature_extractor/extract_youtube.py
+++ b/containers/scheduler_ingest/feature_extractor/extract_youtube.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+# YouTube watch / live / shorts pages embed a server-rendered
+# ytInitialPlayerResponse JSON blob; videoDetails carries the metadata
+# without any JS execution.
+_YT_HOSTS = ("youtube.com", "youtu.be")
+_MARKER = "ytInitialPlayerResponse"
+
+
+def _is_youtube(host: str) -> bool:
+    return any(host == h or host.endswith("." + h) for h in _YT_HOSTS)
+
+
+def _as_int(value) -> int | None:
+    return int(value) if isinstance(value, str) and value.isdigit() else None
+
+
+def extract_youtube(rec: dict):
+    """Return a youtube_video_meta row dict, or None if rec is not a YouTube
+    video page or the metadata blob is missing/unparseable."""
+    if rec.get("status") != "ok":
+        return None
+
+    url = rec.get("url") or ""
+    host = (urlparse(url).hostname or "").lower()
+    if not _is_youtube(host):
+        return None
+
+    content = rec.get("content") or ""
+    i = content.find(_MARKER)
+    if i == -1:
+        return None
+    start = content.find("{", i)
+    if start == -1:
+        return None
+    try:
+        # raw_decode stops at the matching closing brace, so no regex needed.
+        player, _ = json.JSONDecoder().raw_decode(content, start)
+    except ValueError:
+        return None
+
+    vd = player.get("videoDetails") or {}
+    video_id = vd.get("videoId")
+    if not video_id:
+        return None
+
+    return {
+        "video_id": video_id,
+        "url": url,
+        "channel_id": vd.get("channelId"),
+        "channel_title": vd.get("author"),
+        "video_title": vd.get("title"),
+        "view_count": _as_int(vd.get("viewCount")),
+        "length_seconds": _as_int(vd.get("lengthSeconds")),
+        "keywords": vd.get("keywords") or [],
+        "fetched_at": (
+            datetime.fromisoformat(rec["fetched_at"])
+            if rec.get("fetched_at")
+            else datetime.now(timezone.utc)
+        ),
+    }

--- a/containers/scheduler_ingest/feature_extractor/service.py
+++ b/containers/scheduler_ingest/feature_extractor/service.py
@@ -7,6 +7,7 @@ from libs.stats.delta_writer import StatsDeltaWriter
 
 from .db_ops import FeatureDB
 from .extract_basic import extract_basic
+from .extract_youtube import extract_youtube
 
 
 logger = logging.getLogger("extractor")
@@ -44,6 +45,9 @@ class ExtractService:
                     if rec.get("status") == "ok":
                         feat = extract_basic(rec)
                         self.db.process(feat)
+                        yt = extract_youtube(rec)
+                        if yt:
+                            self.db.process_youtube(yt)
                 except Exception as e:
                     logger.error(
                         "extract.record_error",

--- a/scripts/migrate_add_youtube_meta.py
+++ b/scripts/migrate_add_youtube_meta.py
@@ -1,0 +1,83 @@
+"""
+Migration: create the unsharded `youtube_video_meta` table.
+
+Populated by the feature_extractor for any fetched YouTube video page
+(watch / live / shorts) from its server-rendered ytInitialPlayerResponse
+blob. Current-only: each row is upserted on video_id, latest fetch wins.
+
+  video_id       VARCHAR PRIMARY KEY
+  url            VARCHAR
+  channel_id     VARCHAR
+  channel_title  VARCHAR
+  video_title    VARCHAR
+  view_count     BIGINT
+  length_seconds INTEGER
+  keywords       TEXT[]
+  fetched_at     TIMESTAMPTZ
+
+Usage:
+    uv run scripts/migrate_add_youtube_meta.py [--dry-run]
+"""
+
+import argparse
+import logging
+
+import psycopg2
+
+from constants import CRAWLERDB
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger(__name__)
+
+
+STATEMENTS = (
+    """
+    CREATE TABLE IF NOT EXISTS youtube_video_meta (
+      video_id       VARCHAR PRIMARY KEY,
+      url            VARCHAR,
+      channel_id     VARCHAR,
+      channel_title  VARCHAR,
+      video_title    VARCHAR,
+      view_count     BIGINT,
+      length_seconds INTEGER,
+      keywords       TEXT[],
+      fetched_at     TIMESTAMPTZ
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_youtube_video_meta_channel_id "
+    "ON youtube_video_meta (channel_id)",
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create youtube_video_meta table")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print SQL without executing"
+    )
+    args = parser.parse_args()
+
+    conn = psycopg2.connect(**CRAWLERDB)
+    cur = conn.cursor()
+
+    try:
+        for sql in STATEMENTS:
+            if args.dry_run:
+                log.info("[DRY-RUN] %s", " ".join(sql.split()))
+            else:
+                cur.execute(sql)
+
+        if not args.dry_run:
+            conn.commit()
+            log.info("Done: ran %d statements", len(STATEMENTS))
+        else:
+            log.info("[DRY-RUN] Would run %d statements", len(STATEMENTS))
+
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- New `youtube_video_meta` table: per-video view count, channel, title, length, keywords
- Extracted in the feature_extractor from the server-rendered `ytInitialPlayerResponse` blob already present in fetched HTML. No spider / crawl-path change, no columns added to the 256 shard tables.
- Current-only: upsert on `video_id`, latest fetch wins.

## Schema

```sql
CREATE TABLE youtube_video_meta (
  video_id       VARCHAR PRIMARY KEY,
  url            VARCHAR,
  channel_id     VARCHAR,
  channel_title  VARCHAR,
  video_title    VARCHAR,
  view_count     BIGINT,
  length_seconds INTEGER,
  keywords       TEXT[],
  fetched_at     TIMESTAMPTZ
);
```

Unsharded single table, plus a `channel_id` index.

## Changes

- `extract_youtube.py`: parse `videoDetails` for any `youtube.com` / `youtu.be` page (watch / live / shorts). Returns `None` for non-YouTube, failed fetch, or missing/unparseable blob.
- `db_ops.py`: `process_youtube()` upsert on `video_id`.
- `service.py`: call it alongside `extract_basic` in the extract loop.

## Context

Frontier already holds ~6.3M `youtube.com/watch` URLs (~399K fetched). The metadata blob sits in the HTML the extractor already receives, so this only adds a parse + write; views/channel/title/keywords are reliable from `videoDetails` (likes are not, so omitted).

## Usage

```bash
uv run scripts/migrate_add_youtube_meta.py --dry-run
uv run scripts/migrate_add_youtube_meta.py
```